### PR TITLE
Add Thumbor Cloud Storage

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -16,5 +16,6 @@ raven==6.7.0
 thumbor-memcached==5.1.0
 tc-mongodb==5.1.0
 tc-redis==1.0.1
+thumbor-cloud-storage==3.0.0
 pgmagick==0.7.4
 graphicsmagick-engine==0.1.1


### PR DESCRIPTION
To enable this image to be used with Google Cloud Storage, add the
[thumbor-cloud-storage](https://github.com/Superbalist/thumbor-cloud-storage) plugin.