### PR TITLE
Nginx file serving compatible with thumbor 6.6.1+

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -2,4 +2,6 @@ FROM jwilder/nginx-proxy
 
 LABEL maintainer="MinimalCompact"
 
+COPY ./nginx.conf /etc/nginx/
+COPY ./imgpath.js /etc/nginx/
 COPY ./nginx.tmpl /app/

--- a/nginx-proxy/imgpath.js
+++ b/nginx-proxy/imgpath.js
@@ -1,5 +1,5 @@
 function file_path(r) {
-    var uri = decodeURI(r.uri);
+    var uri = decodeURI(r.uri).replace(/(https?):\/(\w)/i, '$1://$2');
     var digest = require('crypto').createHash('sha1').update(uri).digest('hex');
     return digest.slice(NaN, 2) + "/" + digest.slice(2, 4) + "/" + digest.slice(4);
 }

--- a/nginx-proxy/imgpath.js
+++ b/nginx-proxy/imgpath.js
@@ -1,0 +1,7 @@
+function file_path(r) {
+    var url = decodeURI(r.url)
+
+    var digest = require('crypto').createHash('sha1').update(url).digest('hex');
+
+    return "/" + digest.slice(NaN, 2) + "/" + digest.slice(2, 4) + "/" + digest.slice(4);
+}

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -1,0 +1,35 @@
+load_module modules/ngx_http_js_module.so;
+load_module modules/ngx_stream_js_module.so;
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+daemon off;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -1,5 +1,4 @@
 load_module modules/ngx_http_js_module.so;
-load_module modules/ngx_stream_js_module.so;
 
 user  nginx;
 worker_processes  auto;

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -2,7 +2,7 @@
 
 {{ define "thumbor-map" }}
     map $http_accept $webp_prefix {
-        default   "";
+        default   "/default";
         "~*webp*"  "/webp";
     }
     map $request_uri $format {

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -40,7 +40,7 @@
             try_files $webp_prefix/$file_path =404;
             add_header Vary Accept;
         {{ else }}
-            try_files /defaul/$file_path =404;
+            try_files /default/$file_path =404;
         {{ end }}
         error_page  404 = @fetch;
 

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -30,17 +30,17 @@
     {{ $corsOrigin := (first (groupByKeys .Containers "Env.CORS_ALLOW_ORIGIN")) }}
 
     location ~* "^/(?<path>..)(?<path2>..)(.+)?$" {
-        root        /data/result_storage/v2;
+        root        /data/result_storage;
         expires     1M;
 
         {{ if or $allowCors $corsOrigin }}
             {{ template "cors" (dict "CorsOrigin" $corsOrigin) }}
         {{ end }}
         {{ if $autoWebp }}
-            try_files $webp_prefix/$path/$path2$uri =404;
+            try_files $webp_prefix/$file_path =404;
             add_header Vary Accept;
         {{ else }}
-            try_files /$path/$path2$uri =404;
+            try_files /defaul/$file_path =404;
         {{ end }}
         error_page  404 = @fetch;
 
@@ -83,6 +83,9 @@
 	{{ end }}
 	
 {{ end }}
+
+js_include imgpath.js;
+js_set $file_path file_path;
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
 # scheme used to connect to this server


### PR DESCRIPTION
Thumbor [release 6.6.1](https://github.com/thumbor/thumbor/releases/tag/6.6.1) changed the way images are stored on the disc and made Nginx file serving path used in thumbor-nginx-proxy obsolete.

I've made changes to the nginx-proxy so it uses the same hashing mechanism as thumbor.result_storages.file_storage. I've had to use Nginx NJS [Crypto module](https://nginx.org/en/docs/njs/reference.html#crypto) to calculate the file's path.

Now it works as intended as if the file exists on the disk, Nginx serves it directly without making calls to thumbor upstream.