### PR TITLE
Added merge_slashes off to the Nginx config instead of regex in njs

### DIFF
--- a/nginx-proxy/imgpath.js
+++ b/nginx-proxy/imgpath.js
@@ -1,5 +1,5 @@
 function file_path(r) {
-    var uri = decodeURI(r.uri).replace(/(https?):\/(\w)/i, '$1://$2');
+    var uri = decodeURI(r.uri);
     var digest = require('crypto').createHash('sha1').update(uri).digest('hex');
     return digest.slice(NaN, 2) + "/" + digest.slice(2, 4) + "/" + digest.slice(4);
 }

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -1,6 +1,7 @@
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
 {{ define "thumbor-include" }}
+    merge_slashes off;
     js_include imgpath.js;
     js_set $file_path file_path;
 {{ end }}


### PR DESCRIPTION
In previous pull request, we've decided to use `.replace()` to fix the issue when Nginx joins two slashes in url into one. Apparently this could be fixed using standard configuration option http://nginx.org/en/docs/http/ngx_http_core_module.html#merge_slashes