### PR TITLE
[#14] adding a simple benchmark using locust.io

### DIFF
--- a/benchmarks/locust/Dockerfile
+++ b/benchmarks/locust/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6
+
+RUN python3.6 -m pip install locustio==0.11.0
+
+EXPOSE 8089
+EXPOSE 5557
+EXPOSE 5558
+
+CMD ["locust"]

--- a/benchmarks/locust/docker-compose.yml
+++ b/benchmarks/locust/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3"
+services:
+  thumbor:
+    image: minimalcompact/thumbor
+    environment:
+      # we can control the number of processes and threads via ENV
+      - THUMBOR_NUM_PROCESSES=${THUMBOR_NUM_PROCESSES:-1}
+      - ENGINE_THREADPOOL_SIZE=${ENGINE_THREADPOOL_SIZE:-0}
+      # this would allow CORS from any origin (you can restrict to specific origins if you want)
+      - CORS_ALLOW_ORIGIN=*
+      # returns a webp image if browser Accept headers match
+      - AUTO_WEBP=True
+      # no result storage / caching, so we measure thumbor's processing
+      - RESULT_STORAGE=thumbor.result_storages.no_storage
+      - RESULT_STORAGE_STORES_UNSAFE=True
+      # keeping loader storage, to make tests more consistent
+      # (eliminate time to fetch external images)
+      - STORAGE=thumbor.storages.file_storage
+    volumes:
+      # mounting a /data folder to store cached images
+      - ./data:/data
+  # This is the master locust engine
+  locust:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - THUMBOR_DOCKER_PROCS=${THUMBOR_DOCKER_PROCS:-1}
+      - THUMBOR_NUM_PROCESSES=${THUMBOR_NUM_PROCESSES:-1}
+      - ENGINE_THREADPOOL_SIZE=${ENGINE_THREADPOOL_SIZE:-0}
+    volumes:
+      - ./scripts:/opt/scripts
+      - ./reports:/opt/reports
+    command: "locust
+              --host=http://thumbor
+              -f /opt/scripts/benchmark.py
+              --no-web
+              -c 200
+              -r 4
+              --run-time 2m
+              --master
+              --expect-slaves 3
+              --only-summary
+              --csv=/opt/reports/${THUMBOR_DOCKER_PROCS}-${THUMBOR_NUM_PROCESSES}-${ENGINE_THREADPOOL_SIZE}"
+  # this is the locust slave. We can control the number of slaves using docker-compose scale
+  locust-slave:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./scripts:/opt/scripts
+      - ./reports:/opt/reports
+    command: "locust
+              --host=http://thumbor
+              -f /opt/scripts/benchmark.py
+              --no-web
+              --slave
+              --master-host=locust"

--- a/benchmarks/locust/run_benchmark
+++ b/benchmarks/locust/run_benchmark
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+docker-compose build
+docker-compose down
+
+for procs in 1 3 6 9; do
+  for threads in 0 3 6; do
+    export THUMBOR_DOCKER_PROCS=1
+    export THUMBOR_NUM_PROCESSES=$procs
+    export ENGINE_THREADPOOL_SIZE=$threads
+
+    echo
+    echo "***************** BEGIN BENCHMARK WITH ${THUMBOR_DOCKER_PROCS} Docker processes, ${THUMBOR_NUM_PROCESSES} thumbor processes and ${ENGINE_THREADPOOL_SIZE} threads ********************"
+    echo
+    docker-compose up -d --scale locust-slave=3 --scale thumbor=${THUMBOR_DOCKER_PROCS} --force-recreate --always-recreate-deps --renew-anon-volumes
+    docker-compose logs -f locust
+    docker-compose down
+    echo
+    echo "***************** END BENCHMARK WITH ${THUMBOR_DOCKER_PROCS} Docker processes, ${THUMBOR_NUM_PROCESSES} thumbor processes and ${ENGINE_THREADPOOL_SIZE} threads ********************"
+    echo
+  done
+done
+
+for procs in 3 6 9; do
+  for threads in 0 3 6; do
+    export THUMBOR_DOCKER_PROCS=$procs
+    export THUMBOR_NUM_PROCESSES=1
+    export ENGINE_THREADPOOL_SIZE=$threads
+
+    echo
+    echo "***************** BEGIN BENCHMARK WITH ${THUMBOR_DOCKER_PROCS} Docker processes, ${THUMBOR_NUM_PROCESSES} thumbor processes and ${ENGINE_THREADPOOL_SIZE} threads ********************"
+    echo
+    docker-compose up -d --scale locust-slave=3 --scale thumbor=${THUMBOR_DOCKER_PROCS} --force-recreate --always-recreate-deps --renew-anon-volumes
+    docker-compose logs -f locust
+    docker-compose down
+    echo
+    echo "***************** END BENCHMARK WITH ${THUMBOR_DOCKER_PROCS} Docker processes, ${THUMBOR_NUM_PROCESSES} thumbor processes and ${ENGINE_THREADPOOL_SIZE} threads ********************"
+    echo
+  done
+done

--- a/benchmarks/locust/run_benchmark
+++ b/benchmarks/locust/run_benchmark
@@ -38,3 +38,12 @@ for procs in 3 6 9; do
     echo
   done
 done
+
+# combine CSV files into one consolidated file for requests and distribution
+# (it's not super-elegant, but seems to work...)
+cd reports
+cat *_requests.csv |head -1 | sed 's/$/,"Run Configuration"/' >requests.csv
+for i in *_requests.csv; do awk '{print $0 ",\"[" FILENAME "]\"" }' $i | tail -n +2 | sed 's/_requests\.csv//' >> requests.csv; done
+cat *_distribution.csv |head -1 | sed 's/$/,"Run Configuration"/' >distribution.csv
+for i in *_distribution.csv; do awk '{print $0 ",\"[" FILENAME "]\"" }' $i | tail -n +2 | sed 's/_distribution\.csv//' >> distribution.csv; done
+cd ..

--- a/benchmarks/locust/scripts/benchmark.py
+++ b/benchmarks/locust/scripts/benchmark.py
@@ -1,0 +1,19 @@
+from locust import HttpLocust, TaskSet, task
+
+
+class HealthTaskSet(TaskSet):
+    @task
+    def my_task(self):
+        self.client.get('/healthcheck')
+
+class SimpleTaskSet(TaskSet):
+    @task
+    def crop(self):
+        self.client.get('/unsafe/500x150/i.imgur.com/Nfn80ck.png')
+
+    @task
+    def fit_in(self):
+        self.client.get('/unsafe/fit-in/100x150/i.imgur.com/Nfn80ck.png')
+
+class Benchmark(HttpLocust):
+    task_set = SimpleTaskSet


### PR DESCRIPTION
* created a simple [locust](https://locust.io/) benchmark script to cover
  2 types of image manipulation (can be extended to much more)
* running benchmarks with up to 200 concurrent users using 3 locust
  slaves and one master
* running benchmark to compare running with:
  - Docker processes 1-9 (each docker process has 1 thumbor process)
  - Thumbor processes inside docker (one docker process with 1-9 thumbor
    processes)
  - Built-in threads (1-6) for 1-9 docker processes
* was running benchmarks on a 6 virtual core server