### PR TITLE
change remotecv config

### DIFF
--- a/recipes/docker-compose/swarm/docker-compose.yml
+++ b/recipes/docker-compose/swarm/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - REMOTECV_REDIS_HOST=redis
       - REMOTECV_REDIS_PORT=6379
       - REMOTECV_REDIS_DATABASE=0
-      - LOADER=remotecv_aws.loader
+      - REMOTECV_LOADER=remotecv_aws.loader 
       - AWS_ACCESS_KEY_ID= # your AWS_ACCESS_KEY here
       - AWS_SECRET_ACCESS_KEY= # your AWS_SECRET_ACCESS_KEY here
       - AWS_LOADER_BUCKET= # your S3 bucket

--- a/recipes/docker-compose/swarm/docker-compose.yml
+++ b/recipes/docker-compose/swarm/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - REMOTECV_REDIS_HOST=redis
       - REMOTECV_REDIS_PORT=6379
       - REMOTECV_REDIS_DATABASE=0
-      - REMOTECV_LOADER=remotecv_aws.loader 
+      - REMOTECV_LOADER=remotecv_aws.loader
       - AWS_ACCESS_KEY_ID= # your AWS_ACCESS_KEY here
       - AWS_SECRET_ACCESS_KEY= # your AWS_SECRET_ACCESS_KEY here
       - AWS_LOADER_BUCKET= # your S3 bucket


### PR DESCRIPTION
According to https://github.com/MinimalCompact/thumbor/blob/master/remotecv/docker-entrypoint.sh, we should use REMOTECV_LOADER to specify our loader,  instead of LOADER.