### PR TITLE
Fix build installing opencv from pip. Fix pillow-simd builds too

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -11,11 +11,8 @@ RUN  \
     apt-get -y upgrade && \
     apt-get -y autoremove && \
     apt-get install -y -q \
-        python-numpy \
-        python-opencv \
         git \
         curl \
-        libdc1394-22 \
         libjpeg-turbo-progs \
         graphicsmagick \
         libgraphicsmagick++3 \
@@ -43,29 +40,26 @@ ADD conf/circus.ini.tpl /etc/
 RUN mkdir  /etc/circus.d /etc/setup.d
 ADD conf/thumbor-circus.ini.tpl /etc/circus.d/
 
-RUN \
-    ln /usr/lib/python2.7/dist-packages/cv2.x86_64-linux-gnu.so /usr/local/lib/python2.7/cv2.so && \
-    ln /usr/lib/python2.7/dist-packages/cv.py /usr/local/lib/python2.7/cv.py
-
 ARG SIMD_LEVEL
 # workaround for https://github.com/python-pillow/Pillow/issues/3441
 # https://github.com/thumbor/thumbor/issues/1102
 RUN if [ -z "$SIMD_LEVEL" ]; then \
+      CC="cc" && PILLOW_PACKET="pillow" && PILLOW_VERSION_SUFFIX="" ;\
+    else \
+      CC="cc -m$SIMD_LEVEL" && PILLOW_PACKET="pillow-SIMD" && PILLOW_VERSION_SUFFIX=".post99" ;\
+    fi ; \
     PILLOW_VERSION=$(python -c 'import PIL; print(PIL.__version__)') && \
     pip uninstall -y pillow || true && \
     # https://github.com/python-pillow/Pillow/pull/3241
     LIB=/usr/lib/x86_64-linux-gnu/ \
     # https://github.com/python-pillow/Pillow/pull/3237 or https://github.com/python-pillow/Pillow/pull/3245
     INCLUDE=/usr/include/x86_64-linux-gnu/ \
-    pip install --no-cache-dir -U --force-reinstall --no-binary=:all: "pillow<=$PILLOW_VERSION" \
+    pip install --no-cache-dir -U --force-reinstall --no-binary=:all: "${PILLOW_PACKET}<=${PILLOW_VERSION}${PILLOW_VERSION_SUFFIX}" \
     # --global-option="build_ext" --global-option="--debug" \
     --global-option="build_ext" --global-option="--enable-lcms" \
     --global-option="build_ext" --global-option="--enable-zlib" \
     --global-option="build_ext" --global-option="--enable-jpeg" \
-    --global-option="build_ext" --global-option="--enable-tiff" \
-    ; fi
-RUN if [ -n "$SIMD_LEVEL" ]; then apt-get install -y -q libjpeg-dev zlib1g-dev; fi
-RUN if [ -n "$SIMD_LEVEL" ]; then pip uninstall -y pillow; CC="cc -m$SIMD_LEVEL" LDFLAGS=-L/usr/lib/x86_64-linux-gnu/ pip install --no-cache-dir -U --force-reinstall Pillow-SIMD==5.2.0.post0; fi
+    --global-option="build_ext" --global-option="--enable-tiff"
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -43,13 +43,17 @@ ADD conf/thumbor-circus.ini.tpl /etc/circus.d/
 ARG SIMD_LEVEL
 # workaround for https://github.com/python-pillow/Pillow/issues/3441
 # https://github.com/thumbor/thumbor/issues/1102
-RUN if [ -z "$SIMD_LEVEL" ]; then \
+RUN PILLOW_VERSION=$(python -c 'import PIL; print(PIL.__version__)') ; \
+    if [ -z "$SIMD_LEVEL" ]; then \
       CC="cc" && PILLOW_PACKET="pillow" && PILLOW_VERSION_SUFFIX="" ;\
     else \
       CC="cc -m$SIMD_LEVEL" && PILLOW_PACKET="pillow-SIMD" && PILLOW_VERSION_SUFFIX=".post99" ;\
+      # hardcoding to overcome https://github.com/MinimalCompact/thumbor/pull/37#issuecomment-514771902
+      PILLOW_VERSION="5.2.0" ; \
     fi ; \
-    PILLOW_VERSION=$(python -c 'import PIL; print(PIL.__version__)') && \
+
     pip uninstall -y pillow || true && \
+    CC=$CC \
     # https://github.com/python-pillow/Pillow/pull/3241
     LIB=/usr/lib/x86_64-linux-gnu/ \
     # https://github.com/python-pillow/Pillow/pull/3237 or https://github.com/python-pillow/Pillow/pull/3245

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -20,3 +20,4 @@ thumbor-cloud-storage==3.0.0
 pgmagick==0.7.4
 graphicsmagick-engine==0.1.1
 cairosvg==1.0.22
+opencv-python==4.1.0.25


### PR DESCRIPTION
Fixes #36 

I think that would do it.

I am not sure we need to install all these extra packages like `graphicsmagick`, but that is another story.
