### PR TITLE
Add support for AUTO_PNG_TO_JPG env variable

### DIFF
--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -86,6 +86,10 @@ PNG_COMPRESSION_LEVEL = {{ PNG_COMPRESSION_LEVEL | default(6) }}
 ## Defaults to: False
 AUTO_WEBP = {{ AUTO_WEBP | default(False) }}
 
+## Specifies whether non-transparent PNG images should be automatically converted to JPEG
+## Defaults to: False
+AUTO_PNG_TO_JPG = {{ AUTO_PNG_TO_JPG | default(False) }}
+
 ## Specify the ratio between 1in and 1px for SVG images. This is only used
 ## whenrasterizing SVG images having their size units in cm or inches.
 ## Defaults to: 150


### PR DESCRIPTION
Fixes #41 

This exposes the AUTO_PNG_TO_JPG as environment variable.

See https://thumbor.readthedocs.io/en/latest/configuration.html#auto-png-to-jpg for further information about this configuration option.

To test this:
Request a transparent PNG image and define a solid background color via filter. Without the option the image would stay a PNG, now it is converted to a JPEG. Same goes for PNG images that do not include an alpha channel at all.
Since usually AUTO_WEBP is enabled, this of course only affects browsers without WebP support like Safari.