### PR TITLE
Added missing redis configuration

### DIFF
--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -433,6 +433,10 @@ REDIS_STORAGE_SERVER_DB = {{ REDIS_STORAGE_SERVER_DB | default(0) }}
 ## Defaults to: None
 REDIS_STORAGE_SERVER_PASSWORD = {{ REDIS_STORAGE_SERVER_PASSWORD | default(None) }}
 
+## Ignore Redis storage errors
+## Defaults to: True
+REDIS_STORAGE_IGNORE_ERRORS = {{ REDIS_STORAGE_IGNORE_ERRORS | default(True) }}
+
 ################################################################################
 
 
@@ -452,7 +456,11 @@ REDIS_RESULT_STORAGE_SERVER_DB = {{ REDIS_RESULT_STORAGE_SERVER_DB | default(0) 
 
 ## Redis storage server password
 ## Defaults to: None
-REDIS_RESULT_STORAGE_SERVER_PASSWORD = {{ REDIS_STORAGE_SERVER_PASSWORD | default(None) }}
+REDIS_RESULT_STORAGE_SERVER_PASSWORD = {{ REDIS_RESULT_STORAGE_SERVER_PASSWORD | default(None) }}
+
+## Ignore Redis storage errors
+## Defaults to: True
+REDIS_RESULT_STORAGE_IGNORE_ERRORS = {{ REDIS_RESULT_STORAGE_IGNORE_ERRORS | default(True) }}
 
 ################################################################################
 


### PR DESCRIPTION
Add additional redis configuration which is required to use tc_redis

Reference: https://github.com/thumbor-community/redis

Without it, you get the following error:

  File "/usr/local/lib/python2.7/site-packages/tc_redis/storages/redis_storage.py", line 69, in on_redis_error
    if self.context.config.REDIS_STORAGE_IGNORE_ERRORS is True:
  File "/usr/local/lib/python2.7/site-packages/derpconf/config.py", line 223, in __getattr__
    raise AttributeError(name)
AttributeError: REDIS_STORAGE_IGNORE_ERRORS