### PR TITLE
Bump tc_core to 0.4.1, allow to configure community extensions

### DIFF
--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -725,3 +725,6 @@ RESULT_STORAGE_CLOUD_STORAGE_BUCKET_ID = '{{ RESULT_STORAGE_CLOUD_STORAGE_BUCKET
 
 ######################### tc_prometheus ########################################
 PROMETHEUS_SCRAPE_PORT = {{ PROMETHEUS_SCRAPE_PORT | default(8000) }} # Port the prometheus client should listen on
+
+##################### Thumbor Community Extensions #############################
+COMMUNITY_EXTENSIONS = {{ COMMUNITY_EXTENSIONS | default([]) }}

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -10,7 +10,7 @@ opencv-engine==1.0.1
 thumbor==6.7.5
 tornado-botocore==1.5.0
 tc-aws==6.2.15
-tc-core==0.4.0
+tc-core==0.4.1
 tc-shortener==0.2.2
 raven==6.7.0
 thumbor-memcached==5.1.0


### PR DESCRIPTION
* Update `tc_core` to 0.4.1.

See https://github.com/thumbor-community/core/releases/tag/0.4.1 – this fixes a change in more recent versions of Tornado (see [here](https://github.com/thumbor-community/core/pull/17)).

* Allow to pass `COMMUNITY_EXTENSIONS` to the config file

This is how to activate "community" extensions, see https://github.com/thumbor-community/core#quick-setup.
