### PR TITLE
Include Sentry SDK in requirements file

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -23,3 +23,4 @@ cairosvg==1.0.22
 opencv-python==4.1.0.25
 sentry-sdk==1.0.0
 tc_prometheus
+rsa==3.4.2

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -21,4 +21,5 @@ pgmagick==0.7.4
 graphicsmagick-engine==0.1.1
 cairosvg==1.0.22
 opencv-python==4.1.0.25
+sentry-sdk==1.0.0
 tc_prometheus


### PR DESCRIPTION
When trying to use the Sentry env variable thumbor couldn't load the Sentry SDK, by installing the SDK in from the requirements file this will enable the usage of Sentry in from the Docker image directly.

This is also fixing the fallowing issue https://github.com/MinimalCompact/thumbor/issues/75