### PR TITLE
change docker-entrypoint.sh to run thumbor/circus with user privileges

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -22,6 +22,7 @@ RUN  \
         libboost-python-dev \
         libmemcached-dev \
         gifsicle \
+	gosu \
         ffmpeg && \
     apt-get clean
 
@@ -66,7 +67,7 @@ RUN PILLOW_VERSION=$(python -c 'import PIL; print(PIL.__version__)') ; \
     --global-option="build_ext" --global-option="--enable-tiff"
 
 COPY docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["sh", "/docker-entrypoint.sh"]
 
 # running thumbor multiprocess via circus by default
 # to override and run thumbor solo, set THUMBOR_NUM_PROCESSES=1 or unset it

--- a/thumbor/docker-entrypoint.sh
+++ b/thumbor/docker-entrypoint.sh
@@ -23,9 +23,9 @@ fi
 # Create thumbor user with UID 9001
 useradd --shell /bin/bash -u 9001 -o -c "" -m thumbor
 
-# Create /data directory and set its ownership for file_storage
-mkdir -p /data
-chown thumbor:thumbor /data
+# Create storage directories and set ownership for file_storage
+mkdir -p "${FILE_STORAGE_ROOT_PATH:-/data/storage}" "${RESULT_STORAGE_FILE_STORAGE_ROOT_PATH:-/data/result_storage}"
+chown thumbor:thumbor "${FILE_STORAGE_ROOT_PATH:-/data/storage}" "${RESULT_STORAGE_FILE_STORAGE_ROOT_PATH:-/data/result_storage}"
 
 if [ "$1" = 'thumbor' ] || [ "$1" = 'circus' ]; then
     if [ "${THUMBOR_NUM_PROCESSES:-1}" -gt "1" ]; then

--- a/thumbor/docker-entrypoint.sh
+++ b/thumbor/docker-entrypoint.sh
@@ -20,14 +20,21 @@ if [ -z ${THUMBOR_PORT+x} ]; then
     THUMBOR_PORT=80
 fi
 
+# Create thumbor user with UID 9001
+useradd --shell /bin/bash -u 9001 -o -c "" -m thumbor
+
+# Create /data directory and set its ownership for file_storage
+mkdir -p /data
+chown thumbor:thumbor /data
+
 if [ "$1" = 'thumbor' ] || [ "$1" = 'circus' ]; then
     if [ "${THUMBOR_NUM_PROCESSES:-1}" -gt "1" ]; then
         echo "---> Starting thumbor circus with ${THUMBOR_NUM_PROCESSES} processes..."
-        exec /usr/local/bin/circusd /etc/circus.ini
+        exec gosu thumbor /usr/local/bin/circusd /etc/circus.ini
     else
         echo "---> Starting thumbor solo..."
-        exec python -m thumbor/server --port=$THUMBOR_PORT --conf=/app/thumbor.conf $LOG_PARAMETER
+        exec gosu thumbor python -m thumbor/server --port=$THUMBOR_PORT --conf=/app/thumbor.conf $LOG_PARAMETER
     fi
 fi
 
-exec "$@"
+exec gosu thumbor "$@"


### PR DESCRIPTION
Running applications as root even in docker containers [is a risk](https://security.stackexchange.com/q/176206), so I made changes to the `docker-entrypoint.sh` and the Dockerfile to use `gosu` to call thumbor/circus as the newly added user “thumbor”. I also took care of `FILE_STORAGE_ROOT_PATH` and `RESULT_STORAGE_FILE_STORAGE_ROOT_PATH` being accessible to the new user.

Tested with various single- and multiprocess configurations with default as well as user-defined `{,RESULT_STORAGE_}FILE_STORAGE_ROOT_PATH`s.