### PR TITLE
Currently working without using tc-aws

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -30,7 +30,14 @@ ENV SHELL bash
 ENV WORKON_HOME /app
 WORKDIR /app
 
-RUN pip install thumbor==7.0.0a5 envtpl
+COPY proc-requirements.txt /app/proc-requirements.txt
+RUN pip install --trusted-host None --no-cache-dir -r /app/proc-requirements.txt
+RUN pip install thumbor==7.0.0
+COPY lib-requirements.txt /app/lib-requirements.txt
+RUN pip install --trusted-host None --no-cache-dir -r /app/lib-requirements.txt
+RUN pip install --no-dependencies tc-aws==6.2.15
+RUN pip install --no-dependencies tc-core==0.4.1
+RUN pip install --no-dependencies tc-shortener==0.2.2
 
 COPY conf/thumbor.conf.tpl /app/thumbor.conf.tpl
 

--- a/thumbor/conf/thumbor.conf.tpl
+++ b/thumbor/conf/thumbor.conf.tpl
@@ -365,6 +365,8 @@ STORES_CRYPTO_KEY_FOR_EACH_IMAGE = {{ STORES_CRYPTO_KEY_FOR_EACH_IMAGE | default
 ## Defaults to: /tmp/thumbor/storage
 FILE_STORAGE_ROOT_PATH = '{{ FILE_STORAGE_ROOT_PATH | default('/data/storage') }}'
 
+RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = '{{ RESULT_STORAGE_FILE_STORAGE_ROOT_PATH | default('/data/result-storage') }}'
+
 ################################################################################
 
 

--- a/thumbor/lib-requirements.txt
+++ b/thumbor/lib-requirements.txt
@@ -1,0 +1,10 @@
+remotecv==3.0.0
+boto==2.49.0
+tornado-botocore==1.5.0
+python-dateutil
+dateutils==0.6.12
+shortuuid==1.0.8
+redis==3.5.3
+raven==6.10.0
+cairosvg==1.0.22
+pycurl==7.44.1

--- a/thumbor/proc-requirements.txt
+++ b/thumbor/proc-requirements.txt
@@ -1,0 +1,3 @@
+envtpl==0.6.0
+circus==0.15.0
+circus-web==1.0.0


### PR DESCRIPTION
Currently it is working with thumbor's storages and I ported support for tc_aws and other extensions. I didn't bother to update opencv and graphicsmagick engines until we manage to update those as well.

Other storages like redis and mongo still need to be updated as well.

List of packages installed:
* remotecv==3.0.0
* boto==2.49.0
* tornado-botocore==1.5.0
* python-dateutil
* dateutils==0.6.12
* shortuuid==1.0.8
* redis==3.5.3
* raven==6.10.0
* cairosvg==1.0.22
* pycurl==7.44.1

List of packages installed with no-deps:
* tc-aws==6.2.15
* tc-core==0.4.1
* tc-shortener==0.2.2

All the other packages were skipped. Still need to work on them, but this image should be usable now. If someone can help me test the AWS parts it would be great.

Btw running locally with result storage enabled I and 1 thumbor process I got:

```
❯ hit http://localhost:8888/unsafe/500x150/i.imgur.com/Nfn80ck.png
Running 30s test @ http://localhost:8888/unsafe/500x150/i.imgur.com/Nfn80ck.png
  10 threads and 30 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    45.98ms  126.39ms   1.40s    96.35%
    Req/Sec   127.40     17.55   151.00     79.01%
  Latency Distribution
     50%   22.94ms
     75%   23.76ms
     90%   25.06ms
     99%  832.30ms
  36549 requests in 30.03s, 612.14MB read
Requests/sec:   1217.02
```

With 16 processes (on a 16 core CPU) I got this:

```
❯ hit http://localhost:8888/unsafe/500x150/i.imgur.com/Nfn80ck.png
Running 30s test @ http://localhost:8888/unsafe/500x150/i.imgur.com/Nfn80ck.png
  10 threads and 30 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    20.15ms   92.87ms   1.24s    97.53%
    Req/Sec   516.36    343.38     1.41k    70.88%
  Latency Distribution
     50%    5.44ms
     75%   10.01ms
     90%   16.43ms
     99%  617.29ms
  149843 requests in 30.04s, 2.45GB read
Requests/sec:   4987.56
```

(both done using your docker image)

You may say using result storage is cheating, but I'd argue that's the beauty of Thumbor's architecture. It does not depend on the server being incredibly fast (since we need to do things that are CPU intensive like face detection), but it does scale fairly well given the different layers of storage and result storage.

For more information on what changed you can check the release at https://github.com/thumbor/thumbor/releases/tag/7.0.0