### PR TITLE
Be more explicit about which Python base image is being used

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2.7.18-buster
 
 LABEL maintainer="MinimalCompact"
 


### PR DESCRIPTION
To me, it seems `python:2` is in fact resolved to `python:2.7.18-buster`.
