### PR TITLE
envtpl version to 0.7.2

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -1,4 +1,4 @@
-envtpl==0.6.0
+envtpl==0.7.2
 remotecv==3.0.0
 boto==2.49.0
 tornado-botocore==1.5.0


### PR DESCRIPTION
Version is updated to fix `AttributeError: module 'jinja2' has no attribute 'contextfunction'` (described [here](https://github.com/MinimalCompact/thumbor/pull/103#issuecomment-1168511614)).