### PR TITLE
bump to thumbor 7.4.7 (latest)

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -30,7 +30,6 @@ ENV SHELL bash
 ENV WORKON_HOME /app
 WORKDIR /app
 
-RUN pip install thumbor==7.0.0
 COPY requirements.txt /app/requirements.txt
 RUN pip install --trusted-host None --no-cache-dir -r /app/requirements.txt
 RUN pip install --no-dependencies tc-aws==6.2.15

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -1,5 +1,5 @@
 envtpl==0.7.2
-remotecv==3.0.0
+remotecv==3.1.0
 boto==2.49.0
 tornado-botocore==1.5.0
 python-dateutil
@@ -8,4 +8,5 @@ shortuuid==1.0.8
 redis==3.5.3
 raven==6.10.0
 cairosvg==2.5.2
-pycurl==7.44.1
+pycurl==7.45.2
+thumbor==7.4.7


### PR DESCRIPTION
Version 7.0.0 doesn't support remotecv==3.0.0. The next version remotecv==3.1.0 requires Pillow 9, which version 7.0.0 of thumbor requires less than 9. Because of that, I bumped to the latest 7.4.7 and it seems to play nicely and build

