### PR TITLE
Upgrade to Thumbor 7.5.0 and Python 3.11

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11
 
 LABEL maintainer="MinimalCompact"
 

--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -11,5 +11,5 @@ cairosvg==2.5.2
 pycurl==7.45.2
 tc-aws==7.0.2
 tc-core==0.5
-thumbor==7.4.7
+thumbor==7.5.0
 thumbor-wand-engine==0.1.1


### PR DESCRIPTION
Upgrade to latest thumbor (at the moment).

Also, suggesting Python 3.11 as base image as it's supported by 7.5.0 version and it has a faster garbage collector.