### PR TITLE
Upgrade to Thumbor 7.6.0

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -11,5 +11,5 @@ cairosvg==2.5.2
 pycurl==7.45.2
 tc-aws==7.0.2
 tc-core==0.5
-thumbor==7.5.0
+thumbor==7.6.0
 thumbor-wand-engine==0.1.1


### PR DESCRIPTION
Closes #140 

- https://github.com/thumbor/thumbor/releases/tag/7.6.0
  - https://github.com/thumbor/thumbor/pull/1592