### PR TITLE
chore: added opencv-python-headless to requirements.txt

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -6,6 +6,7 @@ python-dateutil
 dateutils==0.6.12
 shortuuid==1.0.8
 redis==3.5.3
+opencv-python-headless==4.8.1.78
 raven==6.10.0
 cairosvg==2.5.2
 pycurl==7.45.2


### PR DESCRIPTION
As reported [here](https://github.com/thumbor/thumbor/issues/1622#issuecomment-1814788431), there is a need to pin `opencv-python-headless` version to [4.8.1.78](https://github.com/opencv/opencv-python/releases/tag/78)

![opencv error](https://user-images.githubusercontent.com/26373096/283522951-20e6484d-9394-4831-9dad-7b3d7c9c89cf.png)