### PR TITLE
Install extra requirements for thumbor

### DIFF
--- a/thumbor/requirements.txt
+++ b/thumbor/requirements.txt
@@ -6,12 +6,8 @@ python-dateutil
 dateutils==0.6.12
 shortuuid==1.0.8
 redis==5.0.1
-opencv-python-headless==4.8.1.78
 raven==6.10.0
-cairosvg==2.7.1
-pycurl==7.45.2
 tc-aws==7.0.2
 tc-core==0.5
-thumbor==7.7.4
+thumbor[all]==7.7.4
 thumbor-wand-engine==0.1.1
-pillow-avif-plugin==1.4.2


### PR DESCRIPTION
Fixes #160

numpy 2 was getting installed rather than numpy 1, so I'm trying to tweak the requirements file to fix that. thumbor lists numpy in it's `extra_require` list, so I'm trying to opt into that using the `[tag]` syntax.

- Syntax is from https://setuptools.pypa.io/en/latest/userguide/dependency_management.html
- thumbor's extra requirements is listed in https://github.com/thumbor/thumbor/blob/252c5b10ff4766b8a09e0a017a11cb9912bf557a/setup.py#L161-L165

This also lets us move the list of extra requirements (cairosvg, pycurl, pillow-avif-plugin) from the requirements file to thumbor's setup.py. We now also pull in pillow-heif to support heif output.

---

I'm not super familiar with pip and dockerfiles so I might've gotten something wrong here. Please help me test it out!